### PR TITLE
Better exceptions

### DIFF
--- a/src/main/kotlin/choliver/neapi/Exceptions.kt
+++ b/src/main/kotlin/choliver/neapi/Exceptions.kt
@@ -5,26 +5,31 @@ abstract class ScraperException : RuntimeException {
   constructor(message: String, cause: Throwable) : super(message, cause)
 }
 
+abstract class NonFatalScraperException : ScraperException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
 // Intentionally skip because we know we aren't dealing with something
-class NotAnItemException : ScraperException {
+class NotAnItemException : NonFatalScraperException {
   constructor(message: String) : super(message)
   constructor(message: String, cause: Throwable) : super(message, cause)
 }
 
 // Input data is malformed in some way
-class MalformedInputException : ScraperException {
+class MalformedInputException : NonFatalScraperException {
   constructor(message: String) : super(message)
   constructor(message: String, cause: Throwable) : super(message, cause)
 }
 
 // Scraped item doesn't pass validation checks
-class InvalidItemException : ScraperException {
+class InvalidItemException : NonFatalScraperException {
   constructor(message: String) : super(message)
   constructor(message: String, cause: Throwable) : super(message, cause)
 }
 
 // Hard fail
-class FatalException : ScraperException {
+class FatalScraperException : ScraperException {
   constructor(message: String) : super(message)
   constructor(message: String, cause: Throwable) : super(message, cause)
 }

--- a/src/main/kotlin/choliver/neapi/Exceptions.kt
+++ b/src/main/kotlin/choliver/neapi/Exceptions.kt
@@ -11,7 +11,7 @@ abstract class NonFatalScraperException : ScraperException {
 }
 
 // Intentionally skip because we know we aren't dealing with something
-class NotAnItemException : NonFatalScraperException {
+class SkipItemException : NonFatalScraperException {
   constructor(message: String) : super(message)
   constructor(message: String, cause: Throwable) : super(message, cause)
 }

--- a/src/main/kotlin/choliver/neapi/Exceptions.kt
+++ b/src/main/kotlin/choliver/neapi/Exceptions.kt
@@ -1,0 +1,30 @@
+package choliver.neapi
+
+abstract class ScraperException : RuntimeException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+// Intentionally skip because we know we aren't dealing with something
+class NotAnItemException : ScraperException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+// Input data is malformed in some way
+class MalformedInputException : ScraperException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+// Scraped item doesn't pass validation checks
+class InvalidItemException : ScraperException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}
+
+// Hard fail
+class FatalException : ScraperException {
+  constructor(message: String) : super(message)
+  constructor(message: String, cause: Throwable) : super(message, cause)
+}

--- a/src/main/kotlin/choliver/neapi/Executor.kt
+++ b/src/main/kotlin/choliver/neapi/Executor.kt
@@ -1,7 +1,6 @@
 package choliver.neapi
 
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result
 import choliver.neapi.getters.Getter
 import choliver.neapi.getters.HtmlGetter
 import mu.KotlinLogging
@@ -17,57 +16,45 @@ class Executor(getter: Getter<String>) {
   inner class ScraperExecutor(private val scraper: Scraper) {
     private val brewery = scraper.name
 
-    fun execute(): List<Item> {
+    fun execute() = scrapeIndexSafely(scraper)
+      .mapNotNull { scrapeItemSafely(it) }
+      .bestPricedItems()
+
+    private fun scrapeIndexSafely(scraper: Scraper): List<IndexEntry> {
       logger.info("[${brewery}] Scraping brewery")
-
-      return scrapeIndexSafely(scraper)
-        .mapNotNull { scrapeItem(it) }
-        .bestPricedItems()
-    }
-
-    private fun scrapeItem(entry: IndexEntry): Item? {
-      logger.info("[${brewery}] Scraping item: ${entry.rawName}")
-
-      return when (val result = scrapeItemSafely(entry)) {
-        is Result.Item -> normaliseItemSafely(entry, result)
-        is Result.Skipped -> {
-          logger.info("[${brewery}] Skipping item because: ${result.reason}")
-          null
-        }
+      return try {
+        scraper.scrapeIndex(jsonGetter.request(scraper.rootUrl))
+      } catch (e: NonFatalScraperException) {
+        logger.warn("[${brewery}] Error scraping brewery", e)
+        emptyList()
+      } catch (e: FatalScraperException) {
+        logger.error("[${brewery}] Fatal error scraping brewery", e)
+        throw e
+      } catch (e: Exception) {
+        logger.warn("[${brewery}] Unexpected error scraping brewery", e)
+        emptyList()
       }
     }
 
-    private fun scrapeIndexSafely(scraper: Scraper): List<IndexEntry> = try {
-      scraper.scrapeIndex(jsonGetter.request(scraper.rootUrl))
-    } catch (e: NonFatalScraperException) {
-      logger.warn("[${brewery}] Error scraping brewery", e)
-      emptyList()
-    } catch (e: FatalScraperException) {
-      logger.error("[${brewery}] Fatal error scraping brewery", e)
-      throw e
-    } catch (e: Exception) {
-      logger.warn("[${brewery}] Unexpected error scraping brewery", e)
-      emptyList()
-    }
-
-    private fun scrapeItemSafely(entry: IndexEntry) = try {
-      entry.scrapeItem(jsonGetter.request(entry.url))
-    } catch (e: NonFatalScraperException) {
-      logger.warn("[${brewery}] Error scraping item: ${entry.rawName}", e)
-      Result.Skipped("Error scraping item") // TODO - eliminate Result.Skipped
-    } catch (e: FatalScraperException) {
-      logger.error("[${brewery}] Error scraping item: ${entry.rawName}", e)
-      throw e
-    } catch (e: Exception) {
-      logger.warn("[${brewery}] Unexpected error scraping item: ${entry.rawName}", e)
-      Result.Skipped("Error scraping item") // TODO - eliminate Result.Skipped
-    }
-
-    private fun normaliseItemSafely(entry: IndexEntry, result: Result.Item) = try {
-      result.normalise(brewery, entry.url)
-    } catch (e: Exception) {
-      logger.error("[${brewery}] Error normalising item: ${entry.rawName}", e)
-      null
+    private fun scrapeItemSafely(entry: IndexEntry): Item? {
+      logger.info("[${brewery}] Scraping item: ${entry.rawName}")
+      return try {
+        entry
+          .scrapeItem(jsonGetter.request(entry.url))
+          .normalise(brewery, entry.url)
+      } catch (e: SkipItemException) {
+        logger.info("[${brewery}] Skipping item because: ${e.message}")
+        null
+      } catch (e: NonFatalScraperException) {
+        logger.warn("[${brewery}] Error scraping item: ${entry.rawName}", e)
+        null
+      } catch (e: FatalScraperException) {
+        logger.error("[${brewery}] Error scraping item: ${entry.rawName}", e)
+        throw e
+      } catch (e: Exception) {
+        logger.warn("[${brewery}] Unexpected error scraping item: ${entry.rawName}", e)
+        null
+      }
     }
 
     private fun List<Item>.bestPricedItems() = groupBy { it.name to it.summary }

--- a/src/main/kotlin/choliver/neapi/ItemNormalisation.kt
+++ b/src/main/kotlin/choliver/neapi/ItemNormalisation.kt
@@ -2,7 +2,7 @@ package choliver.neapi
 
 import java.net.URI
 
-fun Scraper.Result.Item.normalise(brewery: String, url: URI) = Item(
+fun Scraper.Item.normalise(brewery: String, url: URI) = Item(
   brewery = brewery
     .trim()
     .validate("non-blank brewery name") { it.isNotBlank() },

--- a/src/main/kotlin/choliver/neapi/ItemNormalisation.kt
+++ b/src/main/kotlin/choliver/neapi/ItemNormalisation.kt
@@ -29,7 +29,7 @@ fun Scraper.Result.Item.normalise(brewery: String, url: URI) = Item(
 
 private fun <T> T.validate(name: String, predicate: (T) -> Boolean): T {
   if (!predicate(this)) {
-    throw ScraperException("Validation '${name}' failed for value: ${this}")
+    throw InvalidItemException("Validation '${name}' failed for value: ${this}")
   }
   return this
 }

--- a/src/main/kotlin/choliver/neapi/Scraper.kt
+++ b/src/main/kotlin/choliver/neapi/Scraper.kt
@@ -12,20 +12,16 @@ interface Scraper {
   data class IndexEntry(
     val rawName: String,
     val url: URI,
-    val scrapeItem: (doc: Document) -> Result
+    val scrapeItem: (doc: Document) -> Item
   )
 
-  sealed class Result {
-    data class Skipped(val reason: String) : Result()
-    data class Item(
-      val name: String,
-      val summary: String? = null,
-      val perItemPrice: Double,
-      val sizeMl: Int? = null,
-      val abv: Double? = null,
-      val available: Boolean,
-      val thumbnailUrl: URI
-    ) : Result()
-
-  }
+  data class Item(
+    val name: String,
+    val summary: String? = null,
+    val perItemPrice: Double,
+    val sizeMl: Int? = null,
+    val abv: Double? = null,
+    val available: Boolean,
+    val thumbnailUrl: URI
+  )
 }

--- a/src/main/kotlin/choliver/neapi/ScraperException.kt
+++ b/src/main/kotlin/choliver/neapi/ScraperException.kt
@@ -1,6 +1,0 @@
-package choliver.neapi
-
-class ScraperException : RuntimeException {
-  constructor(message: String) : super(message)
-  constructor(message: String, cause: Throwable) : super(message, cause)
-}

--- a/src/main/kotlin/choliver/neapi/ScraperUtils.kt
+++ b/src/main/kotlin/choliver/neapi/ScraperUtils.kt
@@ -21,19 +21,19 @@ fun Element.hrefFrom(cssQuery: String = ":root") = attrFrom(cssQuery, "abs:href"
 fun Element.srcFrom(cssQuery: String = ":root") = attrFrom(cssQuery, "abs:src").toUri()
 
 fun Element.attrFrom(cssQuery: String = ":root", attr: String) = selectFrom(cssQuery).attr(attr)
-  .ifBlank { throw ScraperException("Attribute blank or not present: ${attr}") }!!
+  .ifBlank { throw MalformedInputException("Attribute blank or not present: ${attr}") }!!
 
 fun Element.maybeSelectFrom(cssQuery: String): Element? = selectFirst(cssQuery)
 fun Element.selectFrom(cssQuery: String) = selectFirst(cssQuery)
-  ?: throw ScraperException("Element not present: ${cssQuery}")
+  ?: throw MalformedInputException("Element not present: ${cssQuery}")
 
 fun Element.selectMultipleFrom(cssQuery: String) = maybeSelectMultipleFrom(cssQuery)
-  .ifEmpty { throw ScraperException("Element(s) not present: ${cssQuery}") }
+  .ifEmpty { throw MalformedInputException("Element(s) not present: ${cssQuery}") }
 fun Element.maybeSelectMultipleFrom(cssQuery: String): Elements = select(cssQuery)
 
 
 fun String.extract(regex: String) = maybeExtract(regex)
-  ?: throw ScraperException("Can't extract regex: ${regex}")
+  ?: throw MalformedInputException("Can't extract regex: ${regex}")
 fun String.maybeExtract(regex: String) = regex.toRegex().find(this)?.groupValues
 
 fun String.toTitleCase(): String = split(" ").joinToString(" ") {
@@ -46,7 +46,7 @@ fun Double.divideAsPrice(denominator: Int) = round(100 * this / denominator) / 1
 fun String.toUri() = try {
   URI(this)
 } catch (e: URISyntaxException) {
-  throw ScraperException("URL syntax error: ${this}", e)
+  throw MalformedInputException("URL syntax error: ${this}", e)
 }
 
 private val BEER_ACRONYMS = listOf(

--- a/src/main/kotlin/choliver/neapi/getters/HtmlGetter.kt
+++ b/src/main/kotlin/choliver/neapi/getters/HtmlGetter.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.getters
 
-import choliver.neapi.FatalException
+import choliver.neapi.FatalScraperException
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import java.net.URI
@@ -9,6 +9,6 @@ class HtmlGetter(private val getter: Getter<String>) : Getter<Document> {
   override fun request(url: URI) = try {
     Jsoup.parse(getter.request(url), url.toString())!!
   } catch (e: Exception) {
-    throw FatalException("Could not read page: ${url}", e)
+    throw FatalScraperException("Could not read page: ${url}", e)
   }
 }

--- a/src/main/kotlin/choliver/neapi/getters/HtmlGetter.kt
+++ b/src/main/kotlin/choliver/neapi/getters/HtmlGetter.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.getters
 
-import choliver.neapi.ScraperException
+import choliver.neapi.FatalException
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import java.net.URI
@@ -9,6 +9,6 @@ class HtmlGetter(private val getter: Getter<String>) : Getter<Document> {
   override fun request(url: URI) = try {
     Jsoup.parse(getter.request(url), url.toString())!!
   } catch (e: Exception) {
-    throw ScraperException("Could not read page: ${url}", e)
+    throw FatalException("Could not read page: ${url}", e)
   }
 }

--- a/src/main/kotlin/choliver/neapi/scrapers/BoxcarScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/BoxcarScraper.kt
@@ -2,7 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.Scraper
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.extract
 import choliver.neapi.shopifyItems
 import org.jsoup.nodes.Document

--- a/src/main/kotlin/choliver/neapi/scrapers/CanopyScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/CanopyScraper.kt
@@ -2,8 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
-import choliver.neapi.Scraper.Result.Skipped
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 import kotlin.text.RegexOption.IGNORE_CASE
@@ -24,18 +23,18 @@ class CanopyScraper : Scraper {
         val parts = a.extractFrom(regex = "([^\\d]+) (\\d+(\\.\\d+)?)?")
 
         if (title.contains("box|pack".toRegex(IGNORE_CASE))) {
-          Skipped("Can't extract number of cans for packs")
-        } else {
-          Item(
-            thumbnailUrl = el.srcFrom(".grid__image img"),
-            name = parts[1],
-            summary = null,
-            available = !(el.text().contains("Sold out", ignoreCase = true)),
-            sizeMl = doc.extractFrom(regex = "(\\d+)ml")[1].toInt(),
-            abv = if (parts[2].isBlank()) null else parts[2].toDouble(),
-            perItemPrice = el.extractFrom(regex = "£(\\d+\\.\\d+)")[1].toDouble()
-          )
+          throw SkipItemException("Can't extract number of cans for packs")
         }
+
+        Item(
+          thumbnailUrl = el.srcFrom(".grid__image img"),
+          name = parts[1],
+          summary = null,
+          available = !(el.text().contains("Sold out", ignoreCase = true)),
+          sizeMl = doc.extractFrom(regex = "(\\d+)ml")[1].toInt(),
+          abv = if (parts[2].isBlank()) null else parts[2].toDouble(),
+          perItemPrice = el.extractFrom(regex = "£(\\d+\\.\\d+)")[1].toDouble()
+        )
       }
     }
 }

--- a/src/main/kotlin/choliver/neapi/scrapers/FourpureScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/FourpureScraper.kt
@@ -2,8 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
-import choliver.neapi.Scraper.Result.Skipped
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.net.URI
@@ -20,19 +19,19 @@ class FourpureScraper : Scraper {
 
       IndexEntry(rawName, a.hrefFrom()) { doc ->
         if (el.title().contains("pack", ignoreCase = true)) {
-          Skipped("Can't calculate price-per-can for packs")
-        } else {
-          val parts = extractVariableParts(doc)
-          Item(
-            thumbnailUrl = a.srcFrom("img"),
-            name = parts.name,
-            abv = doc.extractFrom(".brewSheet", "Alcohol By Volume: (\\d+\\.\\d+)")[1].toDouble(),
-            summary = parts.summary,
-            sizeMl = parts.sizeMl,
-            available = true,
-            perItemPrice = el.selectFrom(".priceNow, .priceStandard").priceFrom(".GBP")
-          )
+          throw SkipItemException("Can't calculate price-per-can for packs")
         }
+
+        val parts = extractVariableParts(doc)
+        Item(
+          thumbnailUrl = a.srcFrom("img"),
+          name = parts.name,
+          abv = doc.extractFrom(".brewSheet", "Alcohol By Volume: (\\d+\\.\\d+)")[1].toDouble(),
+          summary = parts.summary,
+          sizeMl = parts.sizeMl,
+          available = true,
+          perItemPrice = el.selectFrom(".priceNow, .priceStandard").priceFrom(".GBP")
+        )
       }
     }
 

--- a/src/main/kotlin/choliver/neapi/scrapers/GipsyHillScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/GipsyHillScraper.kt
@@ -27,7 +27,6 @@ class GipsyHillScraper : Scraper {
         }
         val style = rawSummary.maybeExtract("Style: (.*) ABV")?.get(1)
 
-
         Item(
           thumbnailUrl = a.srcFrom(".attachment-woocommerce_thumbnail"),
           name = name,

--- a/src/main/kotlin/choliver/neapi/scrapers/GipsyHillScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/GipsyHillScraper.kt
@@ -2,7 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 

--- a/src/main/kotlin/choliver/neapi/scrapers/HowlingHopsScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/HowlingHopsScraper.kt
@@ -2,7 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 

--- a/src/main/kotlin/choliver/neapi/scrapers/PillarsScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/PillarsScraper.kt
@@ -2,8 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
-import choliver.neapi.Scraper.Result.Skipped
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 
@@ -19,22 +18,17 @@ class PillarsScraper : Scraper {
         val descParts = doc.maybeExtractFrom(
           ".product-single__description",
           "STYLE:\\s+(.+?)\\s+ABV:\\s+(\\d\\.\\d+)%"
-        )
+        ) ?: throw SkipItemException("Couldn't find style or ABV")  // If we don't see these fields, assume we're not looking at a beer product
 
-        if (descParts == null) {
-          // If we don't see these fields, assume we're not looking at a beer product
-          Skipped("Couldn't find style or ABV")
-        } else {
-          Item(
-            thumbnailUrl = details.thumbnailUrl,
-            name = titleParts.name,
-            summary = if (titleParts.keg) "Minikeg" else descParts[1].toTitleCase(),
-            sizeMl = titleParts.sizeMl,
-            abv = descParts[2].toDouble(),
-            available = details.available,
-            perItemPrice = details.price.divideAsPrice(titleParts.numItems)
-          )
-        }
+        Item(
+          thumbnailUrl = details.thumbnailUrl,
+          name = titleParts.name,
+          summary = if (titleParts.keg) "Minikeg" else descParts[1].toTitleCase(),
+          sizeMl = titleParts.sizeMl,
+          abv = descParts[2].toDouble(),
+          available = details.available,
+          perItemPrice = details.price.divideAsPrice(titleParts.numItems)
+        )
       }
     }
 

--- a/src/main/kotlin/choliver/neapi/scrapers/PressureDropScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/PressureDropScraper.kt
@@ -2,8 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
-import choliver.neapi.Scraper.Result.Skipped
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 
@@ -22,18 +21,18 @@ class PressureDropScraper : Scraper {
         val parts = doc.extractFrom(".product__title", "^(.*?)\\s*(-\\s*(.*?))?$")
 
         if (parts[1].contains("box", ignoreCase = true)) {
-          Skipped("Don't know how to identify number of cans for boxes")
-        } else {
-          Item(
-            thumbnailUrl = a.srcFrom("noscript img"),
-            name = parts[1],
-            summary = parts[3].ifBlank { null },
-            abv = itemText.maybeExtract("(\\d+(\\.\\d+)?)\\s*%")?.get(1)?.toDouble(),
-            sizeMl = itemText.maybeExtract("(\\d+)ml")?.get(1)?.toInt(),
-            available = true,
-            perItemPrice = doc.priceFrom(".ProductPrice")
-          )
+          throw SkipItemException("Don't know how to identify number of cans for boxes")
         }
+
+        Item(
+          thumbnailUrl = a.srcFrom("noscript img"),
+          name = parts[1],
+          summary = parts[3].ifBlank { null },
+          abv = itemText.maybeExtract("(\\d+(\\.\\d+)?)\\s*%")?.get(1)?.toDouble(),
+          sizeMl = itemText.maybeExtract("(\\d+)ml")?.get(1)?.toInt(),
+          available = true,
+          perItemPrice = doc.priceFrom(".ProductPrice")
+        )
       }
     }
 }

--- a/src/main/kotlin/choliver/neapi/scrapers/StewartScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/StewartScraper.kt
@@ -2,8 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
-import choliver.neapi.Scraper.Result.Skipped
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 
@@ -21,18 +20,18 @@ class StewartScraper : Scraper {
         val volume = doc.maybeSelectFrom(".volume")
 
         if (alco == null || volume == null) {
-          Skipped("Couldn't find ABV or volume")
-        } else {
-          Item(
-            thumbnailUrl = el.srcFrom(".imageInnerWrap img"),
-            name = removeSizeSuffix(a.text()),
-            summary = el.maybeTextFrom(".itemStyle"),
-            abv = alco.extractFrom(regex = "(\\d+(\\.\\d+)?)%")[1].toDouble(),
-            sizeMl = volume.extractFrom(regex = "(\\d+)ml")[1].toInt(),
-            available = true,
-            perItemPrice = doc.extractFrom(".priceNow", "£(\\d+\\.\\d+)")[1].toDouble()
-          )
+          throw SkipItemException("Couldn't find ABV or volume")
         }
+
+        Item(
+          thumbnailUrl = el.srcFrom(".imageInnerWrap img"),
+          name = removeSizeSuffix(a.text()),
+          summary = el.maybeTextFrom(".itemStyle"),
+          abv = alco.extractFrom(regex = "(\\d+(\\.\\d+)?)%")[1].toDouble(),
+          sizeMl = volume.extractFrom(regex = "(\\d+)ml")[1].toInt(),
+          available = true,
+          perItemPrice = doc.extractFrom(".priceNow", "£(\\d+\\.\\d+)")[1].toDouble()
+        )
       }
     }
 

--- a/src/main/kotlin/choliver/neapi/scrapers/VillagesScraper.kt
+++ b/src/main/kotlin/choliver/neapi/scrapers/VillagesScraper.kt
@@ -2,7 +2,7 @@ package choliver.neapi.scrapers
 
 import choliver.neapi.*
 import choliver.neapi.Scraper.IndexEntry
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import org.jsoup.nodes.Document
 import java.net.URI
 

--- a/src/main/kotlin/choliver/neapi/storage/GcsObjectStore.kt
+++ b/src/main/kotlin/choliver/neapi/storage/GcsObjectStore.kt
@@ -1,5 +1,6 @@
 package choliver.neapi.storage
 
+import choliver.neapi.FatalScraperException
 import com.google.cloud.storage.BlobId
 import com.google.cloud.storage.BlobInfo
 import com.google.cloud.storage.StorageException
@@ -19,7 +20,7 @@ class GcsObjectStore(private val bucketName: String) : ObjectStore {
     if (e.code == 404) {
       throw FileNotFoundException()
     } else {
-      throw e
+      throw FatalScraperException("Error accessing GCS", e)
     }
   }
 

--- a/src/test/kotlin/choliver/neapi/ExecutorTest.kt
+++ b/src/test/kotlin/choliver/neapi/ExecutorTest.kt
@@ -118,7 +118,7 @@ class ExecutorTest {
     val badScraper = mock<Scraper> {
       on { name } doReturn "Bad Brewing"
       on { rootUrl } doReturn URI("http://bad.invalid")
-      on { scrapeIndex(any()) } doThrow ScraperException("Noooo")
+      on { scrapeIndex(any()) } doThrow MalformedException("Noooo")
     }
 
     assertEquals(
@@ -131,7 +131,7 @@ class ExecutorTest {
   fun `item-scrape failure doesn't jettison everything`() {
     whenever(scraper.scrapeIndex(any())) doReturn listOf(
       indexEntry("a") { SWEET_IPA },
-      indexEntry("b") { throw ScraperException("What happened") },
+      indexEntry("b") { throw MalformedException("What happened") },
       indexEntry("c") { TED_SHANDY }
     )
 

--- a/src/test/kotlin/choliver/neapi/ItemNormalisationTest.kt
+++ b/src/test/kotlin/choliver/neapi/ItemNormalisationTest.kt
@@ -1,6 +1,5 @@
 package choliver.neapi
 
-import choliver.neapi.Scraper.Result
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
@@ -49,25 +48,25 @@ class ItemNormalisationTest {
     assertValidationFailure(prototype.copy(perItemPrice = 10.0))
   }
 
-  private fun assertNoValidationFailure(item: Result.Item) {
+  private fun assertNoValidationFailure(item: Scraper.Item) {
     assertDoesNotThrow {
       normalise(item)
     }
   }
 
-  private fun assertValidationFailure(item: Result.Item) {
-    assertThrows<MalformedException> {
+  private fun assertValidationFailure(item: Scraper.Item) {
+    assertThrows<InvalidItemException> {
       normalise(item)
     }
   }
 
   private fun normalise(
-    item: Result.Item = prototype,
+    item: Scraper.Item = prototype,
     brewery: String = "Foo Bar",
     url: URI = URI("https://example.invalid/shop")
   ) = item.normalise(brewery, url)
 
-  private val prototype = Result.Item(
+  private val prototype = Scraper.Item(
     name = "Ted Shandy",
     summary = "Awful",
     perItemPrice = 1.86,

--- a/src/test/kotlin/choliver/neapi/ItemNormalisationTest.kt
+++ b/src/test/kotlin/choliver/neapi/ItemNormalisationTest.kt
@@ -56,7 +56,7 @@ class ItemNormalisationTest {
   }
 
   private fun assertValidationFailure(item: Result.Item) {
-    assertThrows<ScraperException> {
+    assertThrows<MalformedException> {
       normalise(item)
     }
   }

--- a/src/test/kotlin/choliver/neapi/scrapers/BoxcarScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/BoxcarScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/choliver/neapi/scrapers/CanopyScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/CanopyScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/choliver/neapi/scrapers/FivePointsScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/FivePointsScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse

--- a/src/test/kotlin/choliver/neapi/scrapers/FourpureScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/FourpureScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/src/test/kotlin/choliver/neapi/scrapers/GipsyHillScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/GipsyHillScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull

--- a/src/test/kotlin/choliver/neapi/scrapers/HowlingHopsScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/HowlingHopsScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/choliver/neapi/scrapers/PillarsScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/PillarsScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/choliver/neapi/scrapers/PressureDropScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/PressureDropScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/choliver/neapi/scrapers/StewartScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/StewartScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue

--- a/src/test/kotlin/choliver/neapi/scrapers/VillagesScraperTest.kt
+++ b/src/test/kotlin/choliver/neapi/scrapers/VillagesScraperTest.kt
@@ -1,6 +1,6 @@
 package choliver.neapi.scrapers
 
-import choliver.neapi.Scraper.Result.Item
+import choliver.neapi.Scraper.Item
 import choliver.neapi.executeScraper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
- Introduce more fine-grained exceptions
- Replace `Result.Skipped` with `SkipItemException`.
- Hard-fail on `FatalScraperException` (currently only used for GCS failure).