### PR TITLE
Improve GCS error handling

### DIFF
--- a/src/main/kotlin/watch/craft/network/CachingRetriever.kt
+++ b/src/main/kotlin/watch/craft/network/CachingRetriever.kt
@@ -29,7 +29,6 @@ class CachingRetriever(
         store.write(key, content)
         logger.info("${url} written to cache: ${key}")
       }
-      logger.info("${url} written to cache: ${key}")
     } catch (e: FileExistsException) {
       // Another writer raced us to write to this location in the cache
     }

--- a/src/main/kotlin/watch/craft/storage/GcsObjectStore.kt
+++ b/src/main/kotlin/watch/craft/storage/GcsObjectStore.kt
@@ -7,7 +7,9 @@ import com.google.cloud.storage.Storage.BlobListOption.currentDirectory
 import com.google.cloud.storage.Storage.BlobListOption.prefix
 import com.google.cloud.storage.StorageException
 import com.google.cloud.storage.StorageOptions
+import com.google.common.base.Throwables.getRootCause
 import watch.craft.FatalScraperException
+import java.net.SocketTimeoutException
 
 class GcsObjectStore(
   bucketName: String,
@@ -17,33 +19,57 @@ class GcsObjectStore(
 
   override fun write(key: String, content: ByteArray) {
     try {
-      bucket.create(key, content, doesNotExist())
+      withTimeoutRetries {
+        bucket.create(key, content, doesNotExist())
+      }
     } catch (e: StorageException) {
       if (e.code == 412) {
         throw FileExistsException(key)
       } else {
-        throw FatalScraperException("Error writing to GCS", e)
+        throw FatalScraperException("Error writing to GCS: ${key}", e)
       }
     }
   }
 
   override fun read(key: String) = try {
-    bucket.get(key)?.getContent() ?: throw FileDoesntExistException(key)
+    withTimeoutRetries {
+      bucket.get(key)?.getContent() ?: throw FileDoesntExistException(key)
+    }
   } catch (e: StorageException) {
-    throw FatalScraperException("Error reading from GCS", e)
+    throw FatalScraperException("Error reading from GCS: ${key}", e)
   }
 
   override fun list(key: String) = try {
     val prefix = key.normaliseAsPrefix()
-    bucket.list(prefix(prefix), currentDirectory())
-      .iterateAll()
-      .map { it.name.removePrefix(prefix).removeSuffix("/") }
+    withTimeoutRetries {
+      bucket.list(prefix(prefix), currentDirectory())
+        .iterateAll()
+        .map { it.name.removePrefix(prefix).removeSuffix("/") }
+    }
   } catch (e: StorageException) {
     if (e.code == 404) {
       throw FileDoesntExistException(key)
     } else {
-      throw FatalScraperException("Error reading from GCS", e)
+      throw FatalScraperException("Error reading from GCS: ${key}", e)
     }
+  }
+
+  // TODO - needs to be cancellable
+  // Retry settings for GCS client do not seem to cause it to retry on timeout, so handle this manually.
+  private fun <R> withTimeoutRetries(block: () -> R): R {
+    var exception: StorageException? = null
+    repeat(MAX_RETRIES) { i ->
+      try {
+        return block()
+      } catch (e: StorageException) {
+        if (getRootCause(e) is SocketTimeoutException) {
+          exception = e
+        } else {
+          throw e
+        }
+      }
+    }
+    throw exception!!
   }
 
   private fun String.normaliseAsPrefix() = when {
@@ -55,9 +81,14 @@ class GcsObjectStore(
   companion object {
     fun createGcsService() = StorageOptions.newBuilder().apply {
       setTransportOptions(HttpTransportOptions.newBuilder().apply {
-        setConnectTimeout(60_000)
-        setReadTimeout(60_000)
+        setConnectTimeout(TIMEOUT_MILLIS)
+        setReadTimeout(TIMEOUT_MILLIS)
       }.build())
     }.build().service!!
+
+    private const val TIMEOUT_MILLIS = 10_000
+    private const val MAX_RETRIES = 5
   }
+
+
 }

--- a/src/main/kotlin/watch/craft/storage/GcsObjectStore.kt
+++ b/src/main/kotlin/watch/craft/storage/GcsObjectStore.kt
@@ -58,7 +58,7 @@ class GcsObjectStore(
   // Retry settings for GCS client do not seem to cause it to retry on timeout, so handle this manually.
   private fun <R> withTimeoutRetries(block: () -> R): R {
     var exception: StorageException? = null
-    repeat(MAX_RETRIES) { i ->
+    repeat(MAX_RETRIES) {
       try {
         return block()
       } catch (e: StorageException) {


### PR DESCRIPTION
We get a lot of SocketTimeoutExceptions (possibly due to crappy home ISP).  The GCS client doesn't seem to retry on timeouts (even when the retry settings are explicitly set), so we handle this explicitly in code.