### PR TITLE
Download dir per brewery

### DIFF
--- a/src/main/kotlin/watch/craft/Cli.kt
+++ b/src/main/kotlin/watch/craft/Cli.kt
@@ -28,9 +28,9 @@ class Cli : CliktCommand(name = "scraper") {
   }
 
   private fun executeScrape() {
-    val setup = Setup(dateString, forceDownload)
-    val results = ResultsManager(setup)
-    val executor = Executor(results = results, createRetriever = setup.createRetriever)
+    val structure = StorageStructure(dateString, forceDownload)
+    val results = ResultsManager(structure)
+    val executor = Executor(results = results, createRetriever = structure.createRetriever)
     val inventory = executor.scrape(scrapers.ifEmpty { SCRAPERS })
     results.write(inventory)
   }

--- a/src/main/kotlin/watch/craft/ResultsManager.kt
+++ b/src/main/kotlin/watch/craft/ResultsManager.kt
@@ -28,10 +28,8 @@ class ResultsManager(private val structure: StorageStructure) {
   }
 
   // TODO - simplify this on 2020-08-02
-  fun readMinimalHistoricalResult(timestamp: Instant): MinimalInventory {
-    val minimal = runBlocking {
-      mapper.readValue<MinimalInventory>(dir(timestamp).read(INVENTORY_FILENAME))
-    }
+  suspend fun readMinimalHistoricalResult(timestamp: Instant): MinimalInventory {
+    val minimal = mapper.readValue<MinimalInventory>(dir(timestamp).read(INVENTORY_FILENAME))
     return if (minimal.version == 1) {
       minimal
     } else {

--- a/src/main/kotlin/watch/craft/ResultsManager.kt
+++ b/src/main/kotlin/watch/craft/ResultsManager.kt
@@ -9,7 +9,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter.ISO_DATE_TIME
 
-class ResultsManager(private val setup: Setup) {
+class ResultsManager(private val structure: StorageStructure) {
   private val logger = KotlinLogging.logger {}
   private val mapper = mapper()
 
@@ -20,7 +20,7 @@ class ResultsManager(private val setup: Setup) {
     CANONICAL_INVENTORY_PATH.outputStream().use { mapper.writeValue(it, inventory) }
   }
 
-  fun listHistoricalResults(): List<Instant> = setup.results.list().map { Instant.from(formatter.parse(it)) }
+  fun listHistoricalResults(): List<Instant> = structure.results.list().map { Instant.from(formatter.parse(it)) }
 
   // TODO - simplify this on 2020-08-02
   fun readMinimalHistoricalResult(timestamp: Instant): MinimalInventory {
@@ -40,7 +40,7 @@ class ResultsManager(private val setup: Setup) {
     })
   }
 
-  private fun dir(timestamp: Instant) = SubObjectStore(setup.results, formatter.format(timestamp))
+  private fun dir(timestamp: Instant) = SubObjectStore(structure.results, formatter.format(timestamp))
 
   // TODO - log actual stats once we trust them
   private fun Inventory.logStats() {

--- a/src/main/kotlin/watch/craft/StorageStructure.kt
+++ b/src/main/kotlin/watch/craft/StorageStructure.kt
@@ -1,5 +1,6 @@
 package watch.craft
 
+import com.google.common.annotations.VisibleForTesting
 import watch.craft.network.CachingRetriever
 import watch.craft.network.FailingRetriever
 import watch.craft.network.NetworkRetriever
@@ -10,7 +11,7 @@ import java.time.LocalDate
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 
-class Setup(
+class StorageStructure(
   dateString: String? = null,
   private val forceDownload: Boolean = false,
   firstLevelStore: ObjectStore = LocalObjectStore(LOCAL_STORAGE_DIR),
@@ -31,37 +32,43 @@ class Setup(
 
   val results: ObjectStore = SubObjectStore(store, RESULTS_DIRNAME)
 
-  val downloadsDir: ObjectStore = SubObjectStore(store, "${DOWNLOADS_DIR}/${calculateSubdir()}")
+  @VisibleForTesting
+  fun downloads(id: String) = SubObjectStore(store, "${DOWNLOADS_DIR}/${id}").targetDir()
 
-  val createRetriever: (String) -> Retriever = { name ->
+  val createRetriever: (String) -> Retriever = { id ->
     CachingRetriever(
-      downloadsDir,
+      downloads(id),
       if (live) {
-        NetworkRetriever(name)
+        NetworkRetriever(id)
       } else {
         FailingRetriever()
       }
     )
   }
 
-  private fun calculateSubdir(): String {
+  private fun ObjectStore.targetDir(): ObjectStore {
     val today = DATE_FORMAT.format(instant)
 
-    val subdir = SubObjectStore(store, DOWNLOADS_DIR)
+    val latest = this
       .list()
       .sorted()
       .lastOrNull { it.startsWith(today) }
-      ?: return today
 
-    val parts = subdir.split("--")
-    val idx = if (parts.size < 2) 0 else parts.last().toInt()
-    val idxAdjusted = idx + if (forceDownload) 1 else 0
-
-    return if (idxAdjusted == 0) {
+    val subdir = if (latest == null) {
       today
     } else {
-      "${today}--${idxAdjusted.toString().padStart(3, '0')}"
+      val parts = latest.split("--")
+      val idx = if (parts.size < 2) 0 else parts.last().toInt()
+      val idxAdjusted = idx + if (forceDownload) 1 else 0
+
+      if (idxAdjusted == 0) {
+        today
+      } else {
+        "${today}--${idxAdjusted.toString().padStart(3, '0')}"
+      }
     }
+
+    return SubObjectStore(this, subdir)
   }
 
   companion object {

--- a/src/main/kotlin/watch/craft/StorageStructure.kt
+++ b/src/main/kotlin/watch/craft/StorageStructure.kt
@@ -2,7 +2,6 @@ package watch.craft
 
 import com.google.common.annotations.VisibleForTesting
 import mu.KotlinLogging
-import watch.craft.executor.onIoThread
 import watch.craft.network.CachingRetriever
 import watch.craft.network.FailingRetriever
 import watch.craft.network.NetworkRetriever
@@ -35,34 +34,12 @@ class StorageStructure(
 
   val results: ObjectStore = SubObjectStore(store, RESULTS_DIRNAME)
 
-  private inner class MigratingStore(private val delegate: ObjectStore) : ObjectStore {
-    private val legacy = SubObjectStore(store, "${DOWNLOADS_DIR}/${DATE_FORMAT.format(instant)}")
-    init {
-      logger.info("PATH: ${legacy.path}")
-    }
-
-    override suspend fun write(key: String, content: ByteArray) {
-      TODO("not implemented")
-    }
-
-    override suspend fun read(key: String): ByteArray {
-      val content = legacy.read(key)
-      delegate.write(key, content)
-      return content
-    }
-
-    override suspend fun list(key: String): List<String> {
-      TODO("not implemented")
-    }
-  }
-
-
   @VisibleForTesting
   suspend fun downloads(id: String) = SubObjectStore(store, "${DOWNLOADS_DIR}/${id}").targetDir()
 
   val createRetriever: suspend (String) -> Retriever = { id ->
     CachingRetriever(
-      MigratingStore(downloads(id)),
+      downloads(id),
       if (live) {
         NetworkRetriever(id)
       } else {

--- a/src/main/kotlin/watch/craft/StorageStructure.kt
+++ b/src/main/kotlin/watch/craft/StorageStructure.kt
@@ -50,7 +50,7 @@ class StorageStructure(
   private suspend fun ObjectStore.targetDir(): ObjectStore {
     val today = DATE_FORMAT.format(instant)
 
-    val latest = onIoThread { list() }
+    val latest = list()
       .sorted()
       .lastOrNull { it.startsWith(today) }
 

--- a/src/main/kotlin/watch/craft/executor/Executor.kt
+++ b/src/main/kotlin/watch/craft/executor/Executor.kt
@@ -9,7 +9,7 @@ import java.time.Clock
 
 class Executor(
   private val results: ResultsManager,
-  private val createRetriever: (name: String) -> Retriever,
+  private val createRetriever: suspend (name: String) -> Retriever,
   private val clock: Clock = Clock.systemUTC()
 ) {
   fun scrape(scrapers: Collection<ScraperEntry>) = Context(scrapers).scrape()

--- a/src/main/kotlin/watch/craft/executor/Newalyser.kt
+++ b/src/main/kotlin/watch/craft/executor/Newalyser.kt
@@ -59,7 +59,7 @@ class Newalyser(
   private fun List<Instant>.collateInventory() = runBlocking {
     this@collateInventory
       .map { instant ->
-        async(Dispatchers.IO) {
+        async {
           logger.info("Collating old inventory from: ${instant}")
           results.readMinimalHistoricalResult(instant).items.map { item -> item to instant }
         }

--- a/src/main/kotlin/watch/craft/network/CachingRetriever.kt
+++ b/src/main/kotlin/watch/craft/network/CachingRetriever.kt
@@ -1,7 +1,6 @@
 package watch.craft.network
 
 import mu.KotlinLogging
-import watch.craft.executor.onIoThread
 import watch.craft.storage.FileDoesntExistException
 import watch.craft.storage.FileExistsException
 import watch.craft.storage.ObjectStore

--- a/src/main/kotlin/watch/craft/network/CachingRetriever.kt
+++ b/src/main/kotlin/watch/craft/network/CachingRetriever.kt
@@ -24,23 +24,19 @@ class CachingRetriever(
 
   private suspend fun write(url: URI, key: String, content: ByteArray) {
     try {
-      onIoThread {
-        logger.info("${url} writing to cache on thread: ${currentThread().name}")
-        store.write(key, content)
-        logger.info("${url} written to cache: ${key}")
-      }
+      logger.info("${url} writing to cache on thread: ${currentThread().name}")
+      store.write(key, content)
+      logger.info("${url} written to cache: ${key}")
     } catch (e: FileExistsException) {
       // Another writer raced us to write to this location in the cache
     }
   }
 
   private suspend fun read(url: URI, key: String) = try {
-    onIoThread {
-      logger.info("${url} reading from cache on thread: ${currentThread().name}")
-      val content = store.read(key)
-      logger.info("${url} read from cache: ${key}")
-      content
-    }
+    logger.info("${url} reading from cache on thread: ${currentThread().name}")
+    val content = store.read(key)
+    logger.info("${url} read from cache: ${key}")
+    content
   } catch (e: FileDoesntExistException) {
     null
   }

--- a/src/main/kotlin/watch/craft/network/NetworkRetriever.kt
+++ b/src/main/kotlin/watch/craft/network/NetworkRetriever.kt
@@ -16,7 +16,7 @@ import java.io.IOException
 import java.net.URI
 
 class NetworkRetriever(
-  private val name: String,
+  private val id: String,
   private val rateLimitPeriodMillis: Int = RATE_LIMIT_PERIOD_MILLIS
 ) : Retriever {
   private val logger = KotlinLogging.logger {}
@@ -37,13 +37,13 @@ class NetworkRetriever(
   // coroutine handling requests over a channel.
   init {
     GlobalScope.launch {
-      logger.info("[${name}] Opening client")
+      logger.info("[${id}] Opening client")
       createClient().use { client ->
         for (msg in channel) {
           msg.response.complete(client.process(msg))
         }
       }
-      logger.info("[${name}] Client closed")
+      logger.info("[${id}] Client closed")
     }
   }
 

--- a/src/main/kotlin/watch/craft/storage/LocalObjectStore.kt
+++ b/src/main/kotlin/watch/craft/storage/LocalObjectStore.kt
@@ -1,26 +1,31 @@
 package watch.craft.storage
 
+import watch.craft.executor.onIoThread
 import java.io.File
 import java.io.FileNotFoundException
 
 class LocalObjectStore(private val rootDir: File) : ObjectStore {
-  override fun write(key: String, content: ByteArray) {
-    // TODO - switch to NIO and use copyTo to make this atomic
-    val file = resolveFile(key)
-    if (file.exists()) {
-      throw FileExistsException(file.toString())
+  override suspend fun write(key: String, content: ByteArray) {
+    onIoThread {
+      // TODO - switch to NIO and use copyTo to make this atomic
+      val file = resolveFile(key)
+      if (file.exists()) {
+        throw FileExistsException(file.toString())
+      }
+      file.parentFile.mkdirs()
+      file.writeBytes(content)
     }
-    file.parentFile.mkdirs()
-    file.writeBytes(content)
   }
 
-  override fun read(key: String) = try {
-    resolveFile(key).readBytes()
-  } catch (e: FileNotFoundException) {
-    throw FileDoesntExistException(key)
+  override suspend fun read(key: String) = onIoThread {
+    try {
+      resolveFile(key).readBytes()
+    } catch (e: FileNotFoundException) {
+      throw FileDoesntExistException(key)
+    }
   }
 
-  override fun list(key: String): List<String> {
+  override suspend fun list(key: String): List<String> {
     TODO()
   }
 

--- a/src/main/kotlin/watch/craft/storage/ObjectStore.kt
+++ b/src/main/kotlin/watch/craft/storage/ObjectStore.kt
@@ -4,11 +4,11 @@ interface ObjectStore {
   val path: String get() = ""
 
   @Throws(FileExistsException::class)
-  fun write(key: String, content: ByteArray)
+  suspend fun write(key: String, content: ByteArray)
 
   @Throws(FileDoesntExistException::class)
-  fun read(key: String): ByteArray
+  suspend fun read(key: String): ByteArray
 
   /** Lists direct children. */
-  fun list(key: String = ""): List<String> = emptyList()
+  suspend fun list(key: String = ""): List<String> = emptyList()
 }

--- a/src/main/kotlin/watch/craft/storage/SubObjectStore.kt
+++ b/src/main/kotlin/watch/craft/storage/SubObjectStore.kt
@@ -5,8 +5,8 @@ class SubObjectStore(
   private val base: String
 ) : ObjectStore {
   override val path = "${delegate.path}/${base}"
-  override fun write(key: String, content: ByteArray) = delegate.write(fqk(key), content)
-  override fun read(key: String) = delegate.read(fqk(key))
-  override fun list(key: String) = delegate.list(fqk(key))
+  override suspend fun write(key: String, content: ByteArray) = delegate.write(fqk(key), content)
+  override suspend fun read(key: String) = delegate.read(fqk(key))
+  override suspend fun list(key: String) = delegate.list(fqk(key))
   private fun fqk(key: String) = "${base}/${key}"
 }

--- a/src/main/kotlin/watch/craft/storage/WriteThroughObjectStore.kt
+++ b/src/main/kotlin/watch/craft/storage/WriteThroughObjectStore.kt
@@ -4,7 +4,7 @@ class WriteThroughObjectStore(
   private val firstLevel: ObjectStore,
   private val secondLevel: ObjectStore
 ) : ObjectStore {
-  override fun write(key: String, content: ByteArray) {
+  override suspend fun write(key: String, content: ByteArray) {
     secondLevel.writeGracefully(
       key,
       content
@@ -12,7 +12,7 @@ class WriteThroughObjectStore(
     firstLevel.write(key, content)  // Allow this to throw
   }
 
-  override fun read(key: String) = try {
+  override suspend fun read(key: String) = try {
     firstLevel.read(key)
   } catch (e: FileDoesntExistException) {
     val content = secondLevel.read(key)
@@ -21,9 +21,9 @@ class WriteThroughObjectStore(
   }
 
   // We go straight to second-level storage as source of truth
-  override fun list(key: String) = secondLevel.list(key)
+  override suspend fun list(key: String) = secondLevel.list(key)
 
-  private fun ObjectStore.writeGracefully(key: String, content: ByteArray) {
+  private suspend fun ObjectStore.writeGracefully(key: String, content: ByteArray) {
     try {
       write(key, content)
     } catch (e: FileExistsException) {

--- a/src/test/kotlin/watch/craft/ResultsManagerTest.kt
+++ b/src/test/kotlin/watch/craft/ResultsManagerTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.stub
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import watch.craft.ResultsManager.MinimalInventory
@@ -38,7 +39,7 @@ class ResultsManagerTest {
         version = 1,
         items = listOf(MinimalItem(breweryId = "pollys-brew", name = "Foo"))
       ),
-      manager.readMinimalHistoricalResult(Instant.now())
+      runBlocking { manager.readMinimalHistoricalResult(Instant.now()) }
     )
   }
 
@@ -63,7 +64,7 @@ class ResultsManagerTest {
       MinimalInventory(
         items = listOf(MinimalItem(breweryId = "pollys-brew", name = "Foo"))
       ),
-      manager.readMinimalHistoricalResult(Instant.now())
+      runBlocking { manager.readMinimalHistoricalResult(Instant.now()) }
     )
   }
 
@@ -88,7 +89,7 @@ class ResultsManagerTest {
       MinimalInventory(
         items = emptyList()
       ),
-      manager.readMinimalHistoricalResult(Instant.now())
+      runBlocking { manager.readMinimalHistoricalResult(Instant.now()) }
     )
   }
 }

--- a/src/test/kotlin/watch/craft/ResultsManagerTest.kt
+++ b/src/test/kotlin/watch/craft/ResultsManagerTest.kt
@@ -1,6 +1,9 @@
 package watch.craft
 
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.stub
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import watch.craft.ResultsManager.MinimalInventory

--- a/src/test/kotlin/watch/craft/ResultsManagerTest.kt
+++ b/src/test/kotlin/watch/craft/ResultsManagerTest.kt
@@ -1,9 +1,6 @@
 package watch.craft
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import watch.craft.ResultsManager.MinimalInventory
@@ -29,7 +26,9 @@ class ResultsManagerTest {
       }
     """.trimIndent()
 
-    whenever(store.read(any())) doReturn json.toByteArray()
+    store.stub {
+      onBlocking { read(any()) } doReturn json.toByteArray()
+    }
 
     assertEquals(
       MinimalInventory(
@@ -53,7 +52,9 @@ class ResultsManagerTest {
       }
     """.trimIndent()
 
-    whenever(store.read(any())) doReturn json.toByteArray()
+    store.stub {
+      onBlocking { read(any()) } doReturn json.toByteArray()
+    }
 
     assertEquals(
       MinimalInventory(
@@ -76,7 +77,9 @@ class ResultsManagerTest {
       }
     """.trimIndent()
 
-    whenever(store.read(any())) doReturn json.toByteArray()
+    store.stub {
+      onBlocking { read(any()) } doReturn json.toByteArray()
+    }
 
     assertEquals(
       MinimalInventory(

--- a/src/test/kotlin/watch/craft/StorageStructureTest.kt
+++ b/src/test/kotlin/watch/craft/StorageStructureTest.kt
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import watch.craft.storage.ObjectStore
 
-class SetupTest {
+class StorageStructureTest {
   private val firstLevel = mock<ObjectStore>()
   private val secondLevel = mock<ObjectStore>()
 
@@ -19,27 +19,27 @@ class SetupTest {
     fun `no existing entries for today`() {
       whenever(secondLevel.list(any())) doReturn emptyList()
 
-      val setup = createSetup(false)
+      val structure = createStructure(false)
 
-      assertEquals("/downloads/2020-01-01", setup.downloadsDir.path)
+      assertEquals("/downloads/foo/2020-01-01", structure.downloads("foo").path)
     }
 
     @Test
     fun `one existing entry for today`() {
       whenever(secondLevel.list(any())) doReturn listOf("2020-01-01")
 
-      val setup = createSetup(false)
+      val structure = createStructure(false)
 
-      assertEquals("/downloads/2020-01-01", setup.downloadsDir.path)
+      assertEquals("/downloads/foo/2020-01-01", structure.downloads("foo").path)
     }
 
     @Test
     fun `multiple existing entries for today`() {
       whenever(secondLevel.list(any())) doReturn listOf("2020-01-01--001", "2020-01-01")
 
-      val setup = createSetup(false)
+      val structure = createStructure(false)
 
-      assertEquals("/downloads/2020-01-01--001", setup.downloadsDir.path)
+      assertEquals("/downloads/foo/2020-01-01--001", structure.downloads("foo").path)
     }
   }
 
@@ -49,36 +49,34 @@ class SetupTest {
     fun `no existing entries for today`() {
       whenever(secondLevel.list(any())) doReturn emptyList()
 
-      val setup = createSetup(true)
+      val structure = createStructure(true)
 
-      assertEquals("/downloads/2020-01-01", setup.downloadsDir.path)
+      assertEquals("/downloads/foo/2020-01-01", structure.downloads("foo").path)
     }
 
     @Test
     fun `one existing entry for today`() {
       whenever(secondLevel.list(any())) doReturn listOf("2020-01-01")
 
-      val setup = createSetup(true)
+      val structure = createStructure(true)
 
-      assertEquals("/downloads/2020-01-01--001", setup.downloadsDir.path)
+      assertEquals("/downloads/foo/2020-01-01--001", structure.downloads("foo").path)
     }
 
     @Test
     fun `multiple existing entries for today`() {
       whenever(secondLevel.list(any())) doReturn listOf("2020-01-01--001", "2020-01-01")
 
-      val setup = createSetup(true)
+      val structure = createStructure(true)
 
-      assertEquals("/downloads/2020-01-01--002", setup.downloadsDir.path)
+      assertEquals("/downloads/foo/2020-01-01--002", structure.downloads("foo").path)
     }
   }
 
-  private fun createSetup(forceDownload: Boolean): Setup {
-    return Setup(
-      dateString = "2020-01-01",
-      forceDownload = forceDownload,
-      firstLevelStore = firstLevel,
-      secondLevelStore = secondLevel
-    )
-  }
+  private fun createStructure(forceDownload: Boolean) = StorageStructure(
+    dateString = "2020-01-01",
+    forceDownload = forceDownload,
+    firstLevelStore = firstLevel,
+    secondLevelStore = secondLevel
+  )
 }

--- a/src/test/kotlin/watch/craft/StorageStructureTest.kt
+++ b/src/test/kotlin/watch/craft/StorageStructureTest.kt
@@ -1,9 +1,6 @@
 package watch.craft
 
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
+import com.nhaarman.mockitokotlin2.*
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
@@ -18,7 +15,7 @@ class StorageStructureTest {
   inner class NoForceDownload {
     @Test
     fun `no existing entries for today`() {
-      whenever(secondLevel.list(any())) doReturn emptyList()
+      mockListing(emptyList())
 
       val structure = createStructure(false)
 
@@ -27,7 +24,7 @@ class StorageStructureTest {
 
     @Test
     fun `one existing entry for today`() {
-      whenever(secondLevel.list(any())) doReturn listOf("2020-01-01")
+      mockListing(listOf("2020-01-01"))
 
       val structure = createStructure(false)
 
@@ -36,7 +33,7 @@ class StorageStructureTest {
 
     @Test
     fun `multiple existing entries for today`() {
-      whenever(secondLevel.list(any())) doReturn listOf("2020-01-01--001", "2020-01-01")
+      mockListing(listOf("2020-01-01--001", "2020-01-01"))
 
       val structure = createStructure(false)
 
@@ -48,7 +45,7 @@ class StorageStructureTest {
   inner class ForceDownload {
     @Test
     fun `no existing entries for today`() {
-      whenever(secondLevel.list(any())) doReturn emptyList()
+      mockListing(emptyList())
 
       val structure = createStructure(true)
 
@@ -57,7 +54,7 @@ class StorageStructureTest {
 
     @Test
     fun `one existing entry for today`() {
-      whenever(secondLevel.list(any())) doReturn listOf("2020-01-01")
+      mockListing(listOf("2020-01-01"))
 
       val structure = createStructure(true)
 
@@ -66,12 +63,16 @@ class StorageStructureTest {
 
     @Test
     fun `multiple existing entries for today`() {
-      whenever(secondLevel.list(any())) doReturn listOf("2020-01-01--001", "2020-01-01")
+      mockListing(listOf("2020-01-01--001", "2020-01-01"))
 
       val structure = createStructure(true)
 
       assertEquals("/downloads/foo/2020-01-01--002", getDownloadsPath(structure))
     }
+  }
+
+  private fun mockListing(entries: List<String>) = secondLevel.stub {
+    onBlocking { list(any()) } doReturn entries
   }
 
   private fun getDownloadsPath(structure: StorageStructure) = runBlocking { structure.downloads("foo").path }

--- a/src/test/kotlin/watch/craft/StorageStructureTest.kt
+++ b/src/test/kotlin/watch/craft/StorageStructureTest.kt
@@ -1,6 +1,9 @@
 package watch.craft
 
-import com.nhaarman.mockitokotlin2.*
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.stub
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested

--- a/src/test/kotlin/watch/craft/StorageStructureTest.kt
+++ b/src/test/kotlin/watch/craft/StorageStructureTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,7 +22,7 @@ class StorageStructureTest {
 
       val structure = createStructure(false)
 
-      assertEquals("/downloads/foo/2020-01-01", structure.downloads("foo").path)
+      assertEquals("/downloads/foo/2020-01-01", getDownloadsPath(structure))
     }
 
     @Test
@@ -30,7 +31,7 @@ class StorageStructureTest {
 
       val structure = createStructure(false)
 
-      assertEquals("/downloads/foo/2020-01-01", structure.downloads("foo").path)
+      assertEquals("/downloads/foo/2020-01-01", getDownloadsPath(structure))
     }
 
     @Test
@@ -39,7 +40,7 @@ class StorageStructureTest {
 
       val structure = createStructure(false)
 
-      assertEquals("/downloads/foo/2020-01-01--001", structure.downloads("foo").path)
+      assertEquals("/downloads/foo/2020-01-01--001", getDownloadsPath(structure))
     }
   }
 
@@ -51,7 +52,7 @@ class StorageStructureTest {
 
       val structure = createStructure(true)
 
-      assertEquals("/downloads/foo/2020-01-01", structure.downloads("foo").path)
+      assertEquals("/downloads/foo/2020-01-01", getDownloadsPath(structure))
     }
 
     @Test
@@ -60,7 +61,7 @@ class StorageStructureTest {
 
       val structure = createStructure(true)
 
-      assertEquals("/downloads/foo/2020-01-01--001", structure.downloads("foo").path)
+      assertEquals("/downloads/foo/2020-01-01--001", getDownloadsPath(structure))
     }
 
     @Test
@@ -69,9 +70,11 @@ class StorageStructureTest {
 
       val structure = createStructure(true)
 
-      assertEquals("/downloads/foo/2020-01-01--002", structure.downloads("foo").path)
+      assertEquals("/downloads/foo/2020-01-01--002", getDownloadsPath(structure))
     }
   }
+
+  private fun getDownloadsPath(structure: StorageStructure) = runBlocking { structure.downloads("foo").path }
 
   private fun createStructure(forceDownload: Boolean) = StorageStructure(
     dateString = "2020-01-01",

--- a/src/test/kotlin/watch/craft/TestUtils.kt
+++ b/src/test/kotlin/watch/craft/TestUtils.kt
@@ -9,12 +9,17 @@ import java.net.URI
 private const val GOLDEN_DATE = "2020-07-10"
 
 fun executeScraper(scraper: Scraper, dateString: String? = GOLDEN_DATE) = runBlocking {
+  val id = findBreweryId(scraper)
   ScraperAdapter(
-    StorageStructure(dateString).createRetriever("TEST"),
+    StorageStructure(dateString).createRetriever(id),
     scraper,
-    "TEST"
+    id
   ).execute().entries.map { it.item }
 }
+
+private fun findBreweryId(scraper: Scraper) = SCRAPERS.find { it.scraper.javaClass == scraper.javaClass }
+  ?.brewery?.id
+  ?: throw RuntimeException("Can't find scraper entry")
 
 fun List<ScrapedItem>.byName(name: String) = firstOrNull { it.name == name } ?: fail("No match for '${name}'")
 

--- a/src/test/kotlin/watch/craft/TestUtils.kt
+++ b/src/test/kotlin/watch/craft/TestUtils.kt
@@ -10,7 +10,7 @@ private const val GOLDEN_DATE = "2020-07-10"
 
 fun executeScraper(scraper: Scraper, dateString: String? = GOLDEN_DATE) = runBlocking {
   ScraperAdapter(
-    Setup(dateString).createRetriever("TEST"),
+    StorageStructure(dateString).createRetriever("TEST"),
     scraper,
     "TEST"
   ).execute().entries.map { it.item }

--- a/src/test/kotlin/watch/craft/executor/NewalyserTest.kt
+++ b/src/test/kotlin/watch/craft/executor/NewalyserTest.kt
@@ -139,7 +139,7 @@ class NewalyserTest {
     val manager = mock<ResultsManager> {
       on { listHistoricalResults() } doReturn results.keys.map { daysAgo -> now - Duration.ofDays(daysAgo.toLong()) }
       results.forEach { (daysAgo, items) ->
-        on {
+        onBlocking {
           readMinimalHistoricalResult(now - Duration.ofDays(daysAgo.toLong()))
         } doReturn MinimalInventory(items = items.map { MinimalItem(breweryId = it.breweryId, name = it.name) })
       }

--- a/src/test/kotlin/watch/craft/network/CachingRetrieverTest.kt
+++ b/src/test/kotlin/watch/craft/network/CachingRetrieverTest.kt
@@ -20,7 +20,7 @@ class CachingRetrieverTest {
   @Test
   fun `get from store and not from network if already in store`() {
     store.stub {
-      on { read(NICE_KEY) } doReturn NICE_DATA
+      onBlocking { read(NICE_KEY) } doReturn NICE_DATA
     }
 
     val ret = runBlocking { retriever.retrieve(NICE_URL) }
@@ -32,7 +32,7 @@ class CachingRetrieverTest {
   @Test
   fun `get from network and write to store if not already in store`() {
     store.stub {
-      on { read(NICE_KEY) } doThrow FileDoesntExistException("oh")
+      onBlocking { read(NICE_KEY) } doThrow FileDoesntExistException("oh")
     }
     delegate.stub {
       onBlocking { retrieve(NICE_URL) } doReturn NICE_DATA
@@ -41,14 +41,14 @@ class CachingRetrieverTest {
     val ret = runBlocking { retriever.retrieve(NICE_URL) }
 
     assertArrayEquals(NICE_DATA, ret)
-    verify(store).write(NICE_KEY, NICE_DATA)
+    verifyBlocking(store) { write(NICE_KEY, NICE_DATA) }
   }
 
   @Test
   fun `don't throw if data unexpectedly appears in store when we try to write it`() {
     store.stub {
-      on { read(NICE_KEY) } doThrow FileDoesntExistException("oh")
-      on { store.write(any(), any()) } doThrow FileExistsException("no")
+      onBlocking { read(NICE_KEY) } doThrow FileDoesntExistException("oh")
+      onBlocking { write(any(), any()) } doThrow FileExistsException("no")
     }
     delegate.stub {
       onBlocking { retrieve(NICE_URL) } doReturn NICE_DATA

--- a/src/test/kotlin/watch/craft/scrapers/OrbitScraperTest.kt
+++ b/src/test/kotlin/watch/craft/scrapers/OrbitScraperTest.kt
@@ -11,7 +11,7 @@ import java.net.URI
 
 class OrbitScraperTest {
   companion object {
-    private val ITEMS = executeScraper(OrbitScraper(), dateString = "2020-07-17")
+    private val ITEMS = executeScraper(OrbitScraper(), dateString = "2020-07-18")
   }
 
   @Test

--- a/src/test/kotlin/watch/craft/storage/LocalObjectStoreTest.kt
+++ b/src/test/kotlin/watch/craft/storage/LocalObjectStoreTest.kt
@@ -1,5 +1,6 @@
 package watch.craft.storage
 
+import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.Assertions.assertArrayEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -11,7 +12,7 @@ class LocalObjectStoreTest {
   fun `writes data to filesystem if not already present`(@TempDir tempDir: Path) {
     val store = LocalObjectStore(tempDir.toFile())
 
-    store.write(NICE_KEY, NICE_DATA)
+    runBlocking { store.write(NICE_KEY, NICE_DATA) }
 
     assertArrayEquals(NICE_DATA, tempDir.resolve(NICE_KEY).toFile().readBytes())
   }
@@ -22,7 +23,7 @@ class LocalObjectStoreTest {
     val store = LocalObjectStore(tempDir.toFile())
 
     assertThrows<FileExistsException> {
-      store.write(NICE_KEY, OTHER_DATA)
+      runBlocking { store.write(NICE_KEY, OTHER_DATA) }
     }
     assertArrayEquals(NICE_DATA, tempDir.resolve(NICE_KEY).toFile().readBytes())
   }
@@ -32,7 +33,7 @@ class LocalObjectStoreTest {
     tempDir.resolve(NICE_KEY).toFile().writeBytes(NICE_DATA)
     val store = LocalObjectStore(tempDir.toFile())
 
-    assertArrayEquals(NICE_DATA, store.read(NICE_KEY))
+    assertArrayEquals(NICE_DATA, runBlocking { store.read(NICE_KEY) })
   }
 
   @Test
@@ -40,7 +41,7 @@ class LocalObjectStoreTest {
     val store = LocalObjectStore(tempDir.toFile())
 
     assertThrows<FileDoesntExistException> {
-      store.read(NICE_KEY)
+      runBlocking { store.read(NICE_KEY) }
     }
   }
 


### PR DESCRIPTION
This will allow us to force-download individual breweries without causing subsequent runs to re-download everything.

Downloads data has been migrated (duplicated) by running with the following:

```
  private inner class MigratingStore(private val delegate: ObjectStore) : ObjectStore {
    private val legacy = SubObjectStore(store, "${DOWNLOADS_DIR}/${DATE_FORMAT.format(instant)}")
    init {
      logger.info("LEGACY PATH: ${legacy.path}")
      logger.info("NEW PATH: ${delegate.path}")
    }

    override suspend fun write(key: String, content: ByteArray) {
      TODO("not implemented")
    }

    override suspend fun read(key: String): ByteArray {
      val content = legacy.read(key)
      try {
        delegate.write(key, content)
      } catch (e: FileExistsException) {}
      return content
    }

    override suspend fun list(key: String): List<String> {
      TODO("not implemented")
    }
  }
```